### PR TITLE
Rename confusing profile name

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -6,7 +6,7 @@ version: "1.0.0"
 config-version: 2
 
 # This setting configures which "profile" dbt uses for this project.
-profile: "snowflake"
+profile: "bigquery-jaffle"
 require-dbt-version: ">=1.6.0rc2"
 
 # These configurations specify where dbt should look for different types of files.


### PR DESCRIPTION
Athough `profiles.yml` is not needed on dbt Cloud